### PR TITLE
fix: incorrect variable name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ so later requests will load new values.
 
 ```js
 const myLoader = new DataLoader(keys => {
-  identityLoader.clearAll()
+  myLoader.clearAll()
   return someBatchLoadFn(keys)
 })
 ```


### PR DESCRIPTION
Corrected variable name from `identityLoader` to `myLoader`